### PR TITLE
Add ABAP 7.02 linting workflow

### DIFF
--- a/.github/workflows/ABAP_702.yaml
+++ b/.github/workflows/ABAP_702.yaml
@@ -1,0 +1,22 @@
+name: ABAP_702
+
+on:
+  push:
+    branches: [702]
+
+permissions:
+  contents: read
+
+jobs:
+  ABAP_702:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: 702
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 20
+    - run: npm ci
+    - run: npx abaplint .github/abaplint/abap_702.jsonc

--- a/.github/workflows/ABAP_702.yaml
+++ b/.github/workflows/ABAP_702.yaml
@@ -1,6 +1,9 @@
 name: ABAP_702
 
 on:
+  workflow_run:
+    workflows: [auto_downport]
+    types: [completed]
   push:
     branches: [702]
 
@@ -9,6 +12,7 @@ permissions:
 
 jobs:
   ABAP_702:
+    if: ${{ github.event_name == 'push' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow to run ABAP linting checks specifically for the 702 branch using abaplint.

## Key Changes
- Added `.github/workflows/ABAP_702.yaml` workflow file that:
  - Triggers on pushes to the `702` branch
  - Checks out code from the `702` branch
  - Sets up Node.js 20 runtime environment
  - Installs dependencies via `npm ci`
  - Runs abaplint validation against `.github/abaplint/abap_702.jsonc` configuration

## Implementation Details
- Workflow runs on `ubuntu-latest` with a 10-minute timeout
- Uses minimal permissions (read-only access to repository contents)
- Leverages standard GitHub Actions for checkout and Node.js setup
- Enables automated code quality checks for ABAP 7.02 compatibility

https://claude.ai/code/session_014pz865LcxLkp9rFwsahtBS