### PR TITLE
Fix build script paths and cleanup target directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     },
     "scripts": {
         "clone": "git clone https://github.com/abap2UI5/abap2UI5.git input/abap2UI5",
-        "rename": "abaplint ./.github/abaplint/rename.jsonc --rename && rm -rf src/* && cp -r .github/abaplint/output/workspaces/abap-util/input/abap2UI5/src/00/. src/",
-        "cleanup": "rm -rf input && rm -rf output",
+        "rename": "abaplint ./.github/abaplint/rename.jsonc --rename && rm -rf src/* && cp -r \".github/abaplint/output$(pwd)/input/abap2UI5/src/00\" src/",
+        "cleanup": "rm -rf input && rm -rf .github/abaplint/output",
         "mirror": "npm run clone && npm run rename",
         "syfixes": "find . -type f -name '*.abap' -exec sed -i -e 's/ RAISE EXCEPTION TYPE cx_sy_itab_line_not_found/ ASSERT 1 = 0/g' {} + ",
         "downport": "abaplint --fix .github/abaplint/abap_702.jsonc && npm run syfixes",


### PR DESCRIPTION
## Summary
Updated npm scripts to fix path handling in the rename command and correct the cleanup target directory.

## Key Changes
- **rename script**: Fixed the copy command path to properly handle the abaplint output directory structure by using `$(pwd)` for dynamic path resolution and adding quotes for proper shell escaping
- **cleanup script**: Changed cleanup target from `output` directory to `.github/abaplint/output` to remove build artifacts from the correct location

## Implementation Details
The rename script now uses `".github/abaplint/output$(pwd)/input/abap2UI5/src/00"` instead of the hardcoded `.github/abaplint/output/workspaces/abap-util/input/abap2UI5/src/00/` path, making it more robust to different execution contexts. The cleanup script was updated to target the actual output directory used by the build process.

https://claude.ai/code/session_01Hg49srW6PYXtMF2Jqnes1L