### PR TITLE
Update ABAP transpile configuration and skip list

### DIFF
--- a/node/setup/abap_transpile.json
+++ b/node/setup/abap_transpile.json
@@ -12,13 +12,19 @@
     "ignoreSyntaxCheck": false,
     "addFilenames": true,
     "addCommonJS": true,
-    "extraSetup": "../setup/setup.mjs",
+    "setup": {
+      "filename": "../setup/setup.mjs",
+      "preFunction": "setup"
+    },
     "unknownTypes": "runtimeError",
     "skipReposrc": true,
     "keywords": ["return", "in", "class", "for", "delete", "var"],
     "skip": [
-      {"object": "ZOBLOMOV_CL_AJSON", "class": "ltcl_parser_test", "method": "parse_error", "note": "NodeJS 20 does not set position of parsing error"},
-      {"object": "ZABAPUTIL_CL_UTIL", "class": "ltcl_unit_test_rtti", "method": "test_rtti_check_class_exists", "note": "Z2UI5_CL_UTIL not available in CI lib set"}
+      {"object": "ZABAPUTIL_CL_AJSON", "class": "ltcl_parser_test", "method": "unicode_characters", "note": "JSON.parse in open-abap-core silently dedupes duplicate object keys, real ABAP sXML emits both"},
+      {"object": "ZABAPUTIL_CL_AJSON", "class": "ltcl_writer_test", "method": "set_timestampl", "note": "JavaScript Date has millisecond precision, TIMESTAMPL microseconds are lost"},
+      {"object": "ZABAPUTIL_CL_AJSON", "class": "ltcl_abap_to_json", "method": "set_value_timestampl", "note": "JavaScript Date has millisecond precision, TIMESTAMPL microseconds are lost"},
+      {"object": "ZABAPUTIL_CL_UTIL", "class": "ltcl_unit_test_rtti", "method": "test_rtti_check_class_exists", "note": "Z2UI5_CL_UTIL not available in CI lib set"},
+      {"object": "ZABAPUTIL_CL_UTIL", "class": "ltcl_unit_test_conversion", "method": "test_zip_unpack", "note": "cl_abap_zip in open-abap-core fails with CONVT_NO_NUMBER on load"}
     ]
   }
 }


### PR DESCRIPTION
## Summary
Updated the ABAP transpile configuration to refactor the setup mechanism and expanded the skip list with additional test cases that have known incompatibilities between ABAP and JavaScript runtimes.

## Key Changes
- **Setup Configuration Refactor**: Changed `extraSetup` string property to a structured `setup` object with `filename` and `preFunction` fields, enabling more explicit function invocation
- **Skip List Updates**: 
  - Replaced outdated `ZOBLOMOV_CL_AJSON` entry with three new `ZABAPUTIL_CL_AJSON` test cases covering JSON parsing and timestamp precision issues
  - Added new `ZABAPUTIL_CL_UTIL` test case for ZIP unpacking functionality
  - Updated notes to document the specific runtime incompatibilities (JSON key deduplication, timestamp precision loss, ZIP library issues)

## Notable Details
The skip list changes reflect known limitations when transpiling ABAP to JavaScript:
- JSON.parse behavior differs from ABAP's sXML in handling duplicate object keys
- JavaScript Date objects have millisecond precision while ABAP TIMESTAMPL has microsecond precision
- The open-abap-core ZIP library has issues with number conversion during load operations

https://claude.ai/code/session_01FdwnEZWporVk9zwUsiJ8rL