### PR TITLE
perf(http): cache on-premise request/response references via lazy getters

### DIFF
--- a/src/zabaputil_cl_http.clas.abap
+++ b/src/zabaputil_cl_http.clas.abap
@@ -99,6 +99,18 @@ CLASS zabaputil_cl_http DEFINITION PUBLIC.
   PROTECTED SECTION.
 
   PRIVATE SECTION.
+
+    DATA mo_request_onprem  TYPE REF TO object.
+    DATA mo_response_onprem TYPE REF TO object.
+
+    METHODS get_request_onprem
+      RETURNING
+        VALUE(result) TYPE REF TO object.
+
+    METHODS get_response_onprem
+      RETURNING
+        VALUE(result) TYPE REF TO object.
+
 ENDCLASS.
 
 
@@ -245,12 +257,7 @@ CLASS zabaputil_cl_http IMPLEMENTATION.
 
     IF mo_server_onprem IS BOUND.
 
-      DATA object TYPE REF TO object.
-      FIELD-SYMBOLS <any> TYPE any.
-
-      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
-      ASSERT sy-subrc = 0.
-      object = <any>.
+      DATA(object) = get_response_onprem( ).
 
       CALL METHOD object->(`DELETE_COOKIE`)
         EXPORTING
@@ -262,16 +269,11 @@ CLASS zabaputil_cl_http IMPLEMENTATION.
 
   METHOD get_response_cookie.
 
-    DATA object TYPE REF TO object.
-    FIELD-SYMBOLS <any> TYPE any.
-
     DATA(lv_val) = CONV string( val ).
 
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
-      ASSERT sy-subrc = 0.
-      object = <any>.
+      DATA(object) = get_response_onprem( ).
 
       CALL METHOD object->(`GET_COOKIE`)
         EXPORTING
@@ -285,16 +287,11 @@ CLASS zabaputil_cl_http IMPLEMENTATION.
 
   METHOD get_header_field.
 
-    DATA object TYPE REF TO object.
-    FIELD-SYMBOLS <any> TYPE any.
-
     DATA(lv_val) = CONV string( val ).
 
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->(`REQUEST`) TO <any>.
-      ASSERT sy-subrc = 0.
-      object = <any>.
+      DATA(object) = get_request_onprem( ).
 
       CALL METHOD object->(`GET_HEADER_FIELD`)
         EXPORTING
@@ -316,16 +313,11 @@ CLASS zabaputil_cl_http IMPLEMENTATION.
 
   METHOD set_header_field.
 
-    DATA object TYPE REF TO object.
-    FIELD-SYMBOLS <any> TYPE any.
-
     DATA(lv_n) = CONV string( n ).
     DATA(lv_v) = CONV string( v ).
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
-      ASSERT sy-subrc = 0.
-      object = <any>.
+      DATA(object) = get_response_onprem( ).
 
       CALL METHOD object->(`SET_HEADER_FIELD`)
         EXPORTING
@@ -360,14 +352,9 @@ CLASS zabaputil_cl_http IMPLEMENTATION.
 
   METHOD get_cdata.
 
-    DATA object TYPE REF TO object.
-    FIELD-SYMBOLS <any> TYPE any.
-
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->(`REQUEST`) TO <any>.
-      ASSERT sy-subrc = 0.
-      object = <any>.
+      DATA(object) = get_request_onprem( ).
 
       CALL METHOD object->(`GET_CDATA`)
         RECEIVING
@@ -385,14 +372,9 @@ CLASS zabaputil_cl_http IMPLEMENTATION.
 
   METHOD get_method.
 
-    DATA object TYPE REF TO object.
-    FIELD-SYMBOLS <any> TYPE any.
-
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->(`REQUEST`) TO <any>.
-      ASSERT sy-subrc = 0.
-      object = <any>.
+      DATA(object) = get_request_onprem( ).
 
       CALL METHOD object->(`IF_HTTP_REQUEST~GET_METHOD`)
         RECEIVING
@@ -410,14 +392,9 @@ CLASS zabaputil_cl_http IMPLEMENTATION.
 
   METHOD set_cdata.
 
-    DATA object TYPE REF TO object.
-    FIELD-SYMBOLS <any> TYPE any.
-
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
-      ASSERT sy-subrc = 0.
-      object = <any>.
+      DATA(object) = get_response_onprem( ).
 
       CALL METHOD object->(`SET_CDATA`)
         EXPORTING
@@ -435,16 +412,11 @@ CLASS zabaputil_cl_http IMPLEMENTATION.
 
   METHOD set_status.
 
-    DATA object TYPE REF TO object.
-    FIELD-SYMBOLS <any> TYPE any.
-
     DATA(lv_reason) = CONV string( reason ).
 
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
-      ASSERT sy-subrc = 0.
-      object = <any>.
+      DATA(object) = get_response_onprem( ).
 
       CALL METHOD object->(`IF_HTTP_RESPONSE~SET_STATUS`)
         EXPORTING
@@ -481,6 +453,34 @@ CLASS zabaputil_cl_http IMPLEMENTATION.
     result-method   = get_method( ).
     result-path     = get_header_field( `~path` ).
     result-t_params = zabaputil_cl_util_context=>url_param_get_tab( get_header_field( `~request_uri` ) ).
+
+  ENDMETHOD.
+
+  METHOD get_request_onprem.
+
+    FIELD-SYMBOLS <any> TYPE any.
+
+    IF mo_request_onprem IS NOT BOUND.
+      ASSIGN mo_server_onprem->(`REQUEST`) TO <any>.
+      ASSERT sy-subrc = 0.
+      mo_request_onprem = <any>.
+    ENDIF.
+
+    result = mo_request_onprem.
+
+  ENDMETHOD.
+
+  METHOD get_response_onprem.
+
+    FIELD-SYMBOLS <any> TYPE any.
+
+    IF mo_response_onprem IS NOT BOUND.
+      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
+      ASSERT sy-subrc = 0.
+      mo_response_onprem = <any>.
+    ENDIF.
+
+    result = mo_response_onprem.
 
   ENDMETHOD.
 

--- a/src/zabaputil_cl_http.clas.testclasses.abap
+++ b/src/zabaputil_cl_http.clas.testclasses.abap
@@ -153,6 +153,7 @@ CLASS ltcl_test DEFINITION FINAL
     METHODS test_get_response_cookie  FOR TESTING RAISING cx_static_check.
     METHODS test_delete_resp_cookie   FOR TESTING RAISING cx_static_check.
     METHODS test_set_session_stateful FOR TESTING RAISING cx_static_check.
+    METHODS test_onprem_getter_cache  FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
 
@@ -248,6 +249,32 @@ CLASS ltcl_test IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_equals( exp = 1
                                         act = mo_server->mv_stateful ).
+
+  ENDMETHOD.
+
+  METHOD test_onprem_getter_cache.
+
+    mo_server->request->mv_cdata = `first`.
+    mo_cut->set_cdata( `first` ).
+
+    cl_abap_unit_assert=>assert_equals( exp = `first`
+                                        act = mo_cut->get_cdata( ) ).
+
+    " request/response references are resolved once and then cached -
+    " swapping the objects on the server must not affect the cut anymore
+    DATA(lo_response_old) = mo_server->response.
+    mo_server->request  = NEW #( ).
+    mo_server->response = NEW #( ).
+    mo_server->request->mv_cdata = `second`.
+
+    cl_abap_unit_assert=>assert_equals( exp = `first`
+                                        act = mo_cut->get_cdata( ) ).
+
+    mo_cut->set_cdata( `second` ).
+
+    cl_abap_unit_assert=>assert_equals( exp = `second`
+                                        act = lo_response_old->mv_cdata ).
+    cl_abap_unit_assert=>assert_initial( mo_server->response->mv_cdata ).
 
   ENDMETHOD.
 

--- a/src/zabaputil_cl_util_http.clas.abap
+++ b/src/zabaputil_cl_util_http.clas.abap
@@ -99,6 +99,18 @@ CLASS zabaputil_cl_util_http DEFINITION PUBLIC.
   PROTECTED SECTION.
 
   PRIVATE SECTION.
+
+    DATA mo_request_onprem  TYPE REF TO object.
+    DATA mo_response_onprem TYPE REF TO object.
+
+    METHODS get_request_onprem
+      RETURNING
+        VALUE(result) TYPE REF TO object.
+
+    METHODS get_response_onprem
+      RETURNING
+        VALUE(result) TYPE REF TO object.
+
 ENDCLASS.
 
 
@@ -243,11 +255,7 @@ CLASS zabaputil_cl_util_http IMPLEMENTATION.
 
     IF mo_server_onprem IS BOUND.
 
-      DATA object TYPE REF TO object.
-      FIELD-SYMBOLS <any> TYPE any.
-
-      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
-      object = <any>.
+      DATA(object) = get_response_onprem( ).
 
       CALL METHOD object->(`DELETE_COOKIE`)
         EXPORTING
@@ -265,15 +273,11 @@ CLASS zabaputil_cl_util_http IMPLEMENTATION.
 
   METHOD get_response_cookie.
 
-    DATA object TYPE REF TO object.
-    FIELD-SYMBOLS <any> TYPE any.
-
     DATA(lv_val) = CONV string( val ).
 
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
-      object = <any>.
+      DATA(object) = get_response_onprem( ).
 
       CALL METHOD object->(`GET_COOKIE`)
         EXPORTING
@@ -295,15 +299,11 @@ CLASS zabaputil_cl_util_http IMPLEMENTATION.
 
   METHOD get_header_field.
 
-    DATA object TYPE REF TO object.
-    FIELD-SYMBOLS <any> TYPE any.
-
     DATA(lv_val) = CONV string( val ).
 
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->(`REQUEST`) TO <any>.
-      object = <any>.
+      DATA(object) = get_request_onprem( ).
 
       CALL METHOD object->(`GET_HEADER_FIELD`)
         EXPORTING
@@ -325,15 +325,11 @@ CLASS zabaputil_cl_util_http IMPLEMENTATION.
 
   METHOD set_header_field.
 
-    DATA object TYPE REF TO object.
-    FIELD-SYMBOLS <any> TYPE any.
-
     DATA(lv_n) = CONV string( n ).
     DATA(lv_v) = CONV string( v ).
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
-      object = <any>.
+      DATA(object) = get_response_onprem( ).
 
       CALL METHOD object->(`SET_HEADER_FIELD`)
         EXPORTING
@@ -368,13 +364,9 @@ CLASS zabaputil_cl_util_http IMPLEMENTATION.
 
   METHOD get_cdata.
 
-    DATA object TYPE REF TO object.
-    FIELD-SYMBOLS <any> TYPE any.
-
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->(`REQUEST`) TO <any>.
-      object = <any>.
+      DATA(object) = get_request_onprem( ).
 
       CALL METHOD object->(`GET_CDATA`)
         RECEIVING
@@ -392,13 +384,9 @@ CLASS zabaputil_cl_util_http IMPLEMENTATION.
 
   METHOD get_method.
 
-    DATA object TYPE REF TO object.
-    FIELD-SYMBOLS <any> TYPE any.
-
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->(`REQUEST`) TO <any>.
-      object = <any>.
+      DATA(object) = get_request_onprem( ).
 
       CALL METHOD object->(`IF_HTTP_REQUEST~GET_METHOD`)
         RECEIVING
@@ -416,13 +404,9 @@ CLASS zabaputil_cl_util_http IMPLEMENTATION.
 
   METHOD set_cdata.
 
-    DATA object TYPE REF TO object.
-    FIELD-SYMBOLS <any> TYPE any.
-
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
-      object = <any>.
+      DATA(object) = get_response_onprem( ).
 
       CALL METHOD object->(`SET_CDATA`)
         EXPORTING
@@ -440,15 +424,11 @@ CLASS zabaputil_cl_util_http IMPLEMENTATION.
 
   METHOD set_status.
 
-    DATA object TYPE REF TO object.
-    FIELD-SYMBOLS <any> TYPE any.
-
     DATA(lv_reason) = CONV string( reason ).
 
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
-      object = <any>.
+      DATA(object) = get_response_onprem( ).
 
       CALL METHOD object->(`IF_HTTP_RESPONSE~SET_STATUS`)
         EXPORTING
@@ -489,6 +469,32 @@ CLASS zabaputil_cl_util_http IMPLEMENTATION.
     result-method   = get_method( ).
     result-path     = get_header_field( `~path` ).
     result-t_params = zabaputil_cl_util_context=>url_param_get_tab( get_header_field( `~request_uri` ) ).
+
+  ENDMETHOD.
+
+  METHOD get_request_onprem.
+
+    FIELD-SYMBOLS <any> TYPE any.
+
+    IF mo_request_onprem IS NOT BOUND.
+      ASSIGN mo_server_onprem->(`REQUEST`) TO <any>.
+      mo_request_onprem = <any>.
+    ENDIF.
+
+    result = mo_request_onprem.
+
+  ENDMETHOD.
+
+  METHOD get_response_onprem.
+
+    FIELD-SYMBOLS <any> TYPE any.
+
+    IF mo_response_onprem IS NOT BOUND.
+      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
+      mo_response_onprem = <any>.
+    ENDIF.
+
+    result = mo_response_onprem.
 
   ENDMETHOD.
 

--- a/src/zabaputil_cl_util_http.clas.testclasses.abap
+++ b/src/zabaputil_cl_util_http.clas.testclasses.abap
@@ -153,6 +153,7 @@ CLASS ltcl_test DEFINITION FINAL
     METHODS test_get_response_cookie  FOR TESTING RAISING cx_static_check.
     METHODS test_delete_resp_cookie   FOR TESTING RAISING cx_static_check.
     METHODS test_set_session_stateful FOR TESTING RAISING cx_static_check.
+    METHODS test_onprem_getter_cache  FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
 
@@ -248,6 +249,32 @@ CLASS ltcl_test IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_equals( exp = 1
                                         act = mo_server->mv_stateful ).
+
+  ENDMETHOD.
+
+  METHOD test_onprem_getter_cache.
+
+    mo_server->request->mv_cdata = `first`.
+    mo_cut->set_cdata( `first` ).
+
+    cl_abap_unit_assert=>assert_equals( exp = `first`
+                                        act = mo_cut->get_cdata( ) ).
+
+    " request/response references are resolved once and then cached -
+    " swapping the objects on the server must not affect the cut anymore
+    DATA(lo_response_old) = mo_server->response.
+    mo_server->request  = NEW #( ).
+    mo_server->response = NEW #( ).
+    mo_server->request->mv_cdata = `second`.
+
+    cl_abap_unit_assert=>assert_equals( exp = `first`
+                                        act = mo_cut->get_cdata( ) ).
+
+    mo_cut->set_cdata( `second` ).
+
+    cl_abap_unit_assert=>assert_equals( exp = `second`
+                                        act = lo_response_old->mv_cdata ).
+    cl_abap_unit_assert=>assert_initial( mo_server->response->mv_cdata ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
## Summary

Upstreams the HTTP request/response caching from abap2UI5 commit `c74141e` into the master classes, per the master/copy principle (changes belong here first; abap2UI5 vendors a renamed copy).

- Add private lazy getters `get_request_onprem` / `get_response_onprem` that resolve the dynamic `ASSIGN mo_server_onprem->('REQUEST'/'RESPONSE')` once and cache the reference in `mo_request_onprem` / `mo_response_onprem`.
- Switch all eight on-premise accessors to the getters: `get_cdata`, `get_method`, `get_header_field`, `set_cdata`, `set_status`, `set_header_field`, `get_response_cookie`, `delete_response_cookie` (the master carries more accessors than the trimmed abap2UI5 copy, so all of them are converted here).
- Applied to `zabaputil_cl_util_http` (master of the vendored copy) and its in-repo twin `zabaputil_cl_http` to keep both consistent.
- Public API unchanged — private additions only.

Note: the descriptor-based boolean cache mentioned alongside this change is already upstream (`zabaputil_cl_util_context=>boolean_check_by_data`, landed in #66), so no change was needed there.

## Tests

- New `test_onprem_getter_cache` in both test classes: swaps the fake server's request/response after first access and asserts the cached references are still used.
- `npx abaplint`: 0 issues.
- `npm run auto_transpile && npm run unit`: all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESJ94JKVPqGFBNinVcpcLB

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESJ94JKVPqGFBNinVcpcLB)_