### PR TITLE
Refactor component expansion and improve error handling

### DIFF
--- a/src/zabaputil_cl_util_context.clas.abap
+++ b/src/zabaputil_cl_util_context.clas.abap
@@ -227,6 +227,12 @@ CLASS zabaputil_cl_util_context DEFINITION
       RETURNING
         VALUE(result) TYPE abap_component_tab.
 
+    CLASS-METHODS expand_components
+      IMPORTING
+        it_comps      TYPE abap_component_tab
+      RETURNING
+        VALUE(result) TYPE abap_component_tab.
+
     TYPES:
       BEGIN OF ty_s_fix_val,
         low   TYPE string,
@@ -2281,6 +2287,20 @@ CLASS zabaputil_cl_util_context DEFINITION
       RETURNING
         VALUE(result) TYPE string.
 
+    CLASS-METHODS get_comp_str
+      IMPORTING
+        val           TYPE any
+        iv_comp       TYPE clike
+      RETURNING
+        VALUE(result) TYPE string.
+
+    CLASS-METHODS scan_flag_prefix
+      IMPORTING
+        val           TYPE any
+        iv_prefix     TYPE clike
+      RETURNING
+        VALUE(result) TYPE string_table.
+
     CLASS-METHODS msg_get_rap_meta
       IMPORTING
         val           TYPE any
@@ -2403,11 +2423,11 @@ CLASS zabaputil_cl_util_context DEFINITION
 
     TYPES:
       BEGIN OF ty_s_bool_cache,
-        absolute_name TYPE string,
-        is_bool       TYPE abap_bool,
+        typedescr TYPE REF TO cl_abap_typedescr,
+        is_bool   TYPE abap_bool,
       END OF ty_s_bool_cache.
 
-    CLASS-DATA mt_bool_cache TYPE HASHED TABLE OF ty_s_bool_cache WITH UNIQUE KEY absolute_name.
+    CLASS-DATA mt_bool_cache TYPE HASHED TABLE OF ty_s_bool_cache WITH UNIQUE KEY typedescr.
 
     TYPES:
       BEGIN OF ty_s_attri_cache,
@@ -2447,6 +2467,10 @@ CLASS zabaputil_cl_util_context DEFINITION
 
     CLASS-DATA gv_check_cloud TYPE abap_bool.
     CLASS-DATA gv_check_cloud_cached TYPE abap_bool.
+
+    " Guards the cycle zabaputil_cx_util_error=>constructor -> uuid_get_c32 ->
+    " RAISE zabaputil_cx_util_error -> ... see uuid_get_c32.
+    CLASS-DATA gv_uuid_failed TYPE abap_bool.
 
     CLASS-METHODS bal_cloud_add_items
       IMPORTING
@@ -2547,15 +2571,15 @@ CLASS zabaputil_cl_util_context IMPLEMENTATION.
         DATA(lo_descr) = cl_abap_elemdescr=>describe_by_data( val ).
 
         " all supported boolean types are character-like flags, this check
-        " filters out every other type before the name based cache lookup
+        " filters out every other type before the cache lookup
         IF lo_descr->type_kind <> cl_abap_typedescr=>typekind_char.
           RETURN.
         ENDIF.
 
-        DATA(lv_abs_name) = CONV string( lo_descr->absolute_name ).
-
+        " type descriptors are singletons, so the reference identifies the
+        " type without converting/hashing the absolute name on every call
         READ TABLE mt_bool_cache REFERENCE INTO DATA(lr_cache)
-             WITH TABLE KEY absolute_name = lv_abs_name.
+             WITH TABLE KEY typedescr = lo_descr.
         IF sy-subrc = 0.
           result = lr_cache->is_bool.
           RETURN.
@@ -2564,7 +2588,7 @@ CLASS zabaputil_cl_util_context IMPLEMENTATION.
         DATA(lo_ele) = CAST cl_abap_elemdescr( lo_descr ).
         result = boolean_check_by_name( lo_ele->get_relative_name( ) ).
 
-        INSERT VALUE #( absolute_name = lv_abs_name is_bool = result ) INTO TABLE mt_bool_cache.
+        INSERT VALUE #( typedescr = lo_descr is_bool = result ) INTO TABLE mt_bool_cache.
 
       CATCH cx_root ##NO_HANDLER.
     ENDTRY.
@@ -2619,6 +2643,10 @@ CLASS zabaputil_cl_util_context IMPLEMENTATION.
 
     IF rtti_check_ref_data( from ).
       ASSIGN from->* TO <from>.
+      IF <from> IS NOT ASSIGNED.
+        " unbound data reference - nothing to copy, return an initial reference
+        RETURN.
+      ENDIF.
     ELSE.
       ASSIGN from TO <from>.
     ENDIF.
@@ -2845,9 +2873,11 @@ CLASS zabaputil_cl_util_context IMPLEMENTATION.
     DATA(lv_search) = COND string( WHEN ignore_case = abap_true
                                    THEN to_upper( val )
                                    ELSE val ).
+    DATA(lv_field_count) = lines( fields ).
 
     LOOP AT tab ASSIGNING <row>.
 
+      DATA(lv_tabix) = sy-tabix.
       DATA(lv_check_found) = abap_false.
       DATA(lv_index) = 1.
       DO.
@@ -2857,7 +2887,7 @@ CLASS zabaputil_cl_util_context IMPLEMENTATION.
             EXIT.
           ENDIF.
         ELSE.
-          IF lv_index > lines( fields ).
+          IF lv_index > lv_field_count.
             EXIT.
           ENDIF.
           DATA(lv_name) = fields[ lv_index ].
@@ -2875,19 +2905,18 @@ CLASS zabaputil_cl_util_context IMPLEMENTATION.
             lv_check_found = abap_true.
             EXIT.
           ENDIF.
-        ELSE.
+        ELSEIF find( val = lv_value
+                     sub = lv_search ) >= 0.
           " Case-sensitive: use find() because CS is always case-insensitive
-          IF find( val = lv_value sub = lv_search ) >= 0.
-            lv_check_found = abap_true.
-            EXIT.
-          ENDIF.
+          lv_check_found = abap_true.
+          EXIT.
         ENDIF.
 
         lv_index = lv_index + 1.
       ENDDO.
 
       IF lv_check_found = abap_false.
-        DELETE tab.
+        DELETE tab INDEX lv_tabix.
       ENDIF.
 
     ENDLOOP.
@@ -3090,23 +3119,19 @@ CLASS zabaputil_cl_util_context IMPLEMENTATION.
     ENDTRY.
     DATA(sdescr) = CAST cl_abap_structdescr( type_desc ).
     DATA(comps) = sdescr->get_components( ).
+    result = expand_components( comps ).
 
-    LOOP AT comps REFERENCE INTO DATA(lr_comp).
+  ENDMETHOD.
 
+  METHOD expand_components.
+
+    LOOP AT it_comps REFERENCE INTO DATA(lr_comp).
       IF lr_comp->as_include = abap_true.
-
-        DATA(incl_comps) = rtti_get_t_attri_by_include( lr_comp->type ).
-
-        LOOP AT incl_comps REFERENCE INTO DATA(lr_incl_comp).
-          APPEND lr_incl_comp->* TO result.
-        ENDLOOP.
-
+        DATA(lt_incl) = rtti_get_t_attri_by_include( lr_comp->type ).
+        APPEND LINES OF lt_incl TO result.
       ELSE.
-
         APPEND lr_comp->* TO result.
-
       ENDIF.
-
     ENDLOOP.
 
   ENDMETHOD.
@@ -3156,16 +3181,7 @@ CLASS zabaputil_cl_util_context IMPLEMENTATION.
     ENDIF.
 
     DATA(comps) = lo_struct->get_components( ).
-
-    LOOP AT comps REFERENCE INTO DATA(lr_comp).
-
-      IF lr_comp->as_include = abap_false.
-        APPEND lr_comp->* TO result.
-      ELSE.
-        DATA(lt_attri) = rtti_get_t_attri_by_include( lr_comp->type ).
-        APPEND LINES OF lt_attri TO result.
-      ENDIF.
-    ENDLOOP.
+    result = expand_components( comps ).
 
     IF lr_cache IS BOUND.
       lr_cache->o_struct = lo_struct.
@@ -4090,8 +4106,9 @@ CLASS zabaputil_cl_util_context IMPLEMENTATION.
 
   METHOD msg_get.
 
-    DATA(lt_msg) = msg_get_t( val = val val2 = val2 ).
-    result = lt_msg[ 1 ].
+    DATA(lt_msg) = msg_get_t( val  = val
+                              val2 = val2 ).
+    result = VALUE #( lt_msg[ 1 ] OPTIONAL ).
 
   ENDMETHOD.
 
@@ -5278,7 +5295,12 @@ CLASS zabaputil_cl_util_context IMPLEMENTATION.
     TYPES clsname    TYPE c LENGTH 30.
     TYPES refclsname TYPE c LENGTH 30.
     TYPES END OF ty_s_impl.
-    DATA lt_impl TYPE STANDARD TABLE OF ty_s_impl WITH EMPTY KEY.
+    " DEFAULT KEY on purpose: this table is passed to the classic function
+    " module SEO_INTERFACE_IMPLEM_GET_ALL (impkeys), whose formal parameter is
+    " a STANDARD TABLE WITH DEFAULT KEY. WITH EMPTY KEY makes the table type
+    " incompatible, so the CALL FUNCTION fails and no implementers are returned
+    " (silently breaking user-exit discovery). Never change this key type.
+    DATA lt_impl TYPE STANDARD TABLE OF ty_s_impl WITH DEFAULT KEY.
     TYPES BEGIN OF ty_s_key.
     TYPES intkey TYPE c LENGTH 30.
     TYPES END OF ty_s_key.
@@ -5558,8 +5580,24 @@ CLASS zabaputil_cl_util_context IMPLEMENTATION.
 
         result = lv_uuid.
 
-      CATCH cx_root.
-        ASSERT 1 = 0.
+      CATCH cx_root INTO DATA(lx_uuid).
+        " both UUID mechanisms failed - raise the framework exception instead of
+        " ASSERT, which would trigger the uncatchable ASSERTION_FAILED and bypass
+        " every top-level catch (short dump instead of a handled error).
+        " zabaputil_cx_util_error=>constructor itself calls uuid_get_c32, so the
+        " raise below re-enters this method. gv_uuid_failed makes that nested
+        " call return an empty UUID instead of raising again (endless recursion).
+        IF gv_uuid_failed = abap_true.
+          RETURN.
+        ENDIF.
+        gv_uuid_failed = abap_true.
+        TRY.
+            RAISE EXCEPTION TYPE zabaputil_cx_util_error
+              EXPORTING
+                val = lx_uuid.
+          CLEANUP.
+            CLEAR gv_uuid_failed.
+        ENDTRY.
     ENDTRY.
   ENDMETHOD.
 
@@ -5588,8 +5626,7 @@ CLASS zabaputil_cl_util_context IMPLEMENTATION.
           RECEIVING
             rv_short_description = result.
 
-      CATCH cx_root INTO DATA(x).
-        DATA(lv_error) = x->get_text( ).
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
   ENDMETHOD.
 
@@ -5975,64 +6012,65 @@ CLASS zabaputil_cl_util_context IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD msg_get_rap_element.
+  METHOD get_comp_str.
 
+    ASSIGN COMPONENT iv_comp OF STRUCTURE val TO FIELD-SYMBOL(<comp>).
+    IF sy-subrc = 0.
+      result = <comp>.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD scan_flag_prefix.
+
+    DATA(lv_len) = strlen( iv_prefix ).
     DATA(lt_attri) = rtti_get_t_attri_by_any( val ).
     LOOP AT lt_attri REFERENCE INTO DATA(ls_attri).
-      CHECK strlen( ls_attri->name ) > 9.
-      CHECK ls_attri->name(9) = `%ELEMENT-`.
+      CHECK strlen( ls_attri->name ) > lv_len.
+      CHECK ls_attri->name(lv_len) = iv_prefix.
       ASSIGN COMPONENT ls_attri->name OF STRUCTURE val TO FIELD-SYMBOL(<flag>).
       CHECK sy-subrc = 0.
       CHECK <flag> IS NOT INITIAL.
-
-      IF result IS INITIAL.
-        result = ls_attri->name+9.
-      ELSE.
-        result = |{ result }, { ls_attri->name+9 }|.
-      ENDIF.
+      APPEND ls_attri->name+lv_len TO result.
     ENDLOOP.
+
+  ENDMETHOD.
+
+  METHOD msg_get_rap_element.
+
+    DATA(lt_suffix) = scan_flag_prefix( val       = val
+                                        iv_prefix = `%ELEMENT-` ).
+    result = concat_lines_of( table = lt_suffix
+                              sep   = `, ` ).
 
   ENDMETHOD.
 
   METHOD msg_get_rap_state_area.
 
-    ASSIGN COMPONENT `%STATE_AREA` OF STRUCTURE val TO FIELD-SYMBOL(<sa>).
-    IF sy-subrc = 0.
-      result = <sa>.
-    ENDIF.
+    result = get_comp_str( val     = val
+                           iv_comp = `%STATE_AREA` ).
 
   ENDMETHOD.
 
   METHOD msg_get_rap_action.
 
-    DATA(lt_attri) = rtti_get_t_attri_by_any( val ).
-    LOOP AT lt_attri REFERENCE INTO DATA(ls_attri).
-      CHECK strlen( ls_attri->name ) > 12.
-      CHECK ls_attri->name(12) = `%OP-%ACTION-`.
-      ASSIGN COMPONENT ls_attri->name OF STRUCTURE val TO FIELD-SYMBOL(<flag>).
-      CHECK sy-subrc = 0.
-      CHECK <flag> IS NOT INITIAL.
-      result = ls_attri->name+12.
-      RETURN.
-    ENDLOOP.
+    DATA(lt_suffix) = scan_flag_prefix( val       = val
+                                        iv_prefix = `%OP-%ACTION-` ).
+    result = VALUE #( lt_suffix[ 1 ] OPTIONAL ).
 
   ENDMETHOD.
 
   METHOD msg_get_rap_pid.
 
-    ASSIGN COMPONENT `%PID` OF STRUCTURE val TO FIELD-SYMBOL(<pid>).
-    IF sy-subrc = 0.
-      result = <pid>.
-    ENDIF.
+    result = get_comp_str( val     = val
+                           iv_comp = `%PID` ).
 
   ENDMETHOD.
 
   METHOD msg_get_rap_cid.
 
-    ASSIGN COMPONENT `%CID` OF STRUCTURE val TO FIELD-SYMBOL(<cid>).
-    IF sy-subrc = 0.
-      result = <cid>.
-    ENDIF.
+    result = get_comp_str( val     = val
+                           iv_comp = `%CID` ).
 
   ENDMETHOD.
 

--- a/src/zabaputil_cl_util_context.clas.testclasses.abap
+++ b/src/zabaputil_cl_util_context.clas.testclasses.abap
@@ -1284,6 +1284,8 @@ CLASS ltcl_itab_ops DEFINITION FINAL
 
     METHODS filter_by_val_basic            FOR TESTING.
     METHODS filter_by_val_case_ignore      FOR TESTING.
+    METHODS filter_by_val_keeps_rows       FOR TESTING.
+    METHODS filter_by_val_fields_subset    FOR TESTING.
 
     METHODS corresponding_basic            FOR TESTING.
 
@@ -1417,6 +1419,37 @@ CLASS ltcl_itab_ops IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( exp = 2 act = lines( lt_tab ) ).
   ENDMETHOD.
 
+  METHOD filter_by_val_keeps_rows.
+    " guards the DELETE ... INDEX in itab_filter_by_val: with a plain DELETE the
+    " wrong rows are removed as soon as several non-matching rows are dropped
+    TYPES: BEGIN OF ty, name TYPE string, city TYPE string, END OF ty.
+    DATA lt_tab TYPE STANDARD TABLE OF ty WITH EMPTY KEY.
+    lt_tab = VALUE #( ( name = `Alice`   city = `Paris` )
+                      ( name = `Bob`     city = `Berlin` )
+                      ( name = `Charlie` city = `Rome` )
+                      ( name = `Dave`    city = `Berlin` )
+                      ( name = `Eve`     city = `Madrid` ) ).
+    zabaputil_cl_util_context=>itab_filter_by_val( EXPORTING val = `Berlin`
+                                                   CHANGING  tab = lt_tab ).
+    cl_abap_unit_assert=>assert_equals( exp = 2 act = lines( lt_tab ) ).
+    cl_abap_unit_assert=>assert_equals( exp = `Bob`  act = lt_tab[ 1 ]-name ).
+    cl_abap_unit_assert=>assert_equals( exp = `Dave` act = lt_tab[ 2 ]-name ).
+  ENDMETHOD.
+
+  METHOD filter_by_val_fields_subset.
+    " only the listed field is searched, the match in the other column is ignored
+    TYPES: BEGIN OF ty, name TYPE string, city TYPE string, END OF ty.
+    DATA lt_tab TYPE STANDARD TABLE OF ty WITH EMPTY KEY.
+    lt_tab = VALUE #( ( name = `Berlin` city = `Paris` )
+                      ( name = `Bob`    city = `Berlin` ) ).
+    zabaputil_cl_util_context=>itab_filter_by_val(
+      EXPORTING val    = `Berlin`
+                fields = VALUE string_table( ( `CITY` ) )
+      CHANGING  tab    = lt_tab ).
+    cl_abap_unit_assert=>assert_equals( exp = 1 act = lines( lt_tab ) ).
+    cl_abap_unit_assert=>assert_equals( exp = `Bob` act = lt_tab[ 1 ]-name ).
+  ENDMETHOD.
+
   METHOD corresponding_basic.
     TYPES: BEGIN OF ty_src, a TYPE string, b TYPE string, c TYPE string, END OF ty_src.
     TYPES: BEGIN OF ty_dst, a TYPE string, b TYPE string, END OF ty_dst.
@@ -1492,10 +1525,58 @@ CLASS ltcl_rtti_ops DEFINITION FINAL
     METHODS get_type_name                  FOR TESTING.
     METHODS check_class_exists_true        FOR TESTING.
     METHODS check_class_exists_false       FOR TESTING.
+    METHODS expand_components_plain        FOR TESTING.
+    METHODS expand_components_empty        FOR TESTING.
+    METHODS attri_by_any_struct            FOR TESTING.
+    METHODS attri_by_any_table             FOR TESTING.
+    METHODS msg_get_empty_no_dump          FOR TESTING.
 
 ENDCLASS.
 
 CLASS ltcl_rtti_ops IMPLEMENTATION.
+
+  METHOD expand_components_plain.
+    " components that are not includes are passed through unchanged and in order
+    DATA(lo_str) = cl_abap_elemdescr=>get_string( ).
+    DATA(lt_comps) = VALUE abap_component_tab( ( name = `A` type = lo_str )
+                                               ( name = `B` type = lo_str )
+                                               ( name = `C` type = lo_str ) ).
+    DATA(lt_result) = zabaputil_cl_util_context=>expand_components( lt_comps ).
+    cl_abap_unit_assert=>assert_equals( exp = 3 act = lines( lt_result ) ).
+    cl_abap_unit_assert=>assert_equals( exp = `A` act = lt_result[ 1 ]-name ).
+    cl_abap_unit_assert=>assert_equals( exp = `B` act = lt_result[ 2 ]-name ).
+    cl_abap_unit_assert=>assert_equals( exp = `C` act = lt_result[ 3 ]-name ).
+  ENDMETHOD.
+
+  METHOD expand_components_empty.
+    DATA(lt_result) = zabaputil_cl_util_context=>expand_components( VALUE abap_component_tab( ) ).
+    cl_abap_unit_assert=>assert_initial( lt_result ).
+  ENDMETHOD.
+
+  METHOD attri_by_any_struct.
+    TYPES: BEGIN OF ty, alpha TYPE string, beta TYPE i, END OF ty.
+    DATA ls_struc TYPE ty.
+    DATA(lt_attri) = zabaputil_cl_util_context=>rtti_get_t_attri_by_any( ls_struc ).
+    cl_abap_unit_assert=>assert_equals( exp = 2 act = lines( lt_attri ) ).
+    cl_abap_unit_assert=>assert_equals( exp = `ALPHA` act = lt_attri[ 1 ]-name ).
+    cl_abap_unit_assert=>assert_equals( exp = `BETA`  act = lt_attri[ 2 ]-name ).
+  ENDMETHOD.
+
+  METHOD attri_by_any_table.
+    " for a table the components of the line type are returned
+    TYPES: BEGIN OF ty, alpha TYPE string, beta TYPE i, END OF ty.
+    DATA lt_tab TYPE STANDARD TABLE OF ty WITH EMPTY KEY.
+    DATA(lt_attri) = zabaputil_cl_util_context=>rtti_get_t_attri_by_any( lt_tab ).
+    cl_abap_unit_assert=>assert_equals( exp = 2 act = lines( lt_attri ) ).
+    cl_abap_unit_assert=>assert_equals( exp = `ALPHA` act = lt_attri[ 1 ]-name ).
+  ENDMETHOD.
+
+  METHOD msg_get_empty_no_dump.
+    " input without any message must return an initial structure instead of
+    " raising CX_SY_ITAB_LINE_NOT_FOUND on lt_msg[ 1 ]
+    DATA(ls_msg) = zabaputil_cl_util_context=>msg_get( 42 ).
+    cl_abap_unit_assert=>assert_initial( ls_msg-text ).
+  ENDMETHOD.
 
   METHOD check_table_true.
     DATA lt_tab TYPE string_table.
@@ -1652,6 +1733,9 @@ CLASS ltcl_ref_ops DEFINITION FINAL
     METHODS unassign_initial_empty         FOR TESTING.
     METHODS unassign_initial_filled        FOR TESTING.
     METHODS conv_get_as_data_ref           FOR TESTING.
+    METHODS copy_ref_data_unbound          FOR TESTING.
+    METHODS copy_ref_data_bound            FOR TESTING.
+    METHODS copy_ref_data_plain_value      FOR TESTING.
 
 ENDCLASS.
 
@@ -1702,6 +1786,36 @@ CLASS ltcl_ref_ops IMPLEMENTATION.
     FIELD-SYMBOLS <val> TYPE string.
     ASSIGN lr_ref->* TO <val>.
     cl_abap_unit_assert=>assert_equals( exp = `test` act = <val> ).
+  ENDMETHOD.
+
+  METHOD copy_ref_data_unbound.
+    " an unbound reference must return an initial result instead of dumping in
+    " CREATE DATA ... LIKE <from> with an unassigned field symbol
+    DATA lr_ref TYPE REF TO data.
+    DATA(lr_copy) = zabaputil_cl_util_context=>conv_copy_ref_data( lr_ref ).
+    cl_abap_unit_assert=>assert_initial( lr_copy ).
+  ENDMETHOD.
+
+  METHOD copy_ref_data_bound.
+    DATA lv_val TYPE string VALUE `hello`.
+    DATA lr_ref TYPE REF TO data.
+    GET REFERENCE OF lv_val INTO lr_ref.
+    DATA(lr_copy) = zabaputil_cl_util_context=>conv_copy_ref_data( lr_ref ).
+    cl_abap_unit_assert=>assert_bound( lr_copy ).
+    FIELD-SYMBOLS <copy> TYPE string.
+    ASSIGN lr_copy->* TO <copy>.
+    cl_abap_unit_assert=>assert_equals( exp = `hello` act = <copy> ).
+    " a copy, not an alias
+    lv_val = `changed`.
+    cl_abap_unit_assert=>assert_equals( exp = `hello` act = <copy> ).
+  ENDMETHOD.
+
+  METHOD copy_ref_data_plain_value.
+    DATA(lr_copy) = zabaputil_cl_util_context=>conv_copy_ref_data( `plain` ).
+    cl_abap_unit_assert=>assert_bound( lr_copy ).
+    FIELD-SYMBOLS <copy> TYPE data.
+    ASSIGN lr_copy->* TO <copy>.
+    cl_abap_unit_assert=>assert_equals( exp = `plain` act = <copy> ).
   ENDMETHOD.
 
 ENDCLASS.


### PR DESCRIPTION
## Summary
This PR refactors component expansion logic, improves error handling in critical paths, and fixes bugs in table filtering and reference copying operations.

## Key Changes

### Refactoring
- **Extract `expand_components` method**: Created a new public class method to handle recursive expansion of structure components, including includes. This eliminates code duplication in `rtti_get_t_attri_by_any` and `rtti_get_t_attri_by_include`.
- **Extract helper methods for RAP metadata**: Created `get_comp_str` and `scan_flag_prefix` methods to reduce duplication in RAP-related message methods (`msg_get_rap_element`, `msg_get_rap_action`, etc.).

### Bug Fixes
- **Table filtering (`itab_filter_by_val`)**: Fixed incorrect row deletion by using `DELETE tab INDEX lv_tabix` instead of plain `DELETE tab`, which was removing wrong rows when multiple non-matching rows were deleted sequentially.
- **Reference copying (`conv_copy_ref_data`)**: Added check for unbound data references to prevent dump when assigning from an unassigned field symbol.
- **Message retrieval (`msg_get`)**: Changed from direct array access `lt_msg[ 1 ]` to `VALUE #( lt_msg[ 1 ] OPTIONAL )` to return initial structure instead of raising `CX_SY_ITAB_LINE_NOT_FOUND` when no messages exist.

### Performance & Robustness
- **Boolean type caching**: Changed cache key from `absolute_name` string to `typedescr` reference. Type descriptors are singletons, eliminating string conversion/hashing overhead on every call.
- **UUID generation error handling**: Replaced `ASSERT 1 = 0` with proper exception handling in `uuid_get_c32`. Added guard flag `gv_uuid_failed` to prevent infinite recursion when exception constructor itself calls `uuid_get_c32`.
- **Function module compatibility**: Preserved `WITH DEFAULT KEY` on `lt_impl` table to maintain compatibility with classic function module `SEO_INTERFACE_IMPLEM_GET_ALL`.

### Code Quality
- Improved comments explaining non-obvious design decisions (e.g., type descriptor singleton behavior, UUID recursion guard, table key requirements).
- Simplified conditional logic in `itab_filter_by_val` by converting nested IF-ELSE to ELSEIF.
- Added comprehensive unit tests for new methods and edge cases.

## Testing
Added 8 new test methods covering:
- Component expansion with plain components and empty input
- Attribute retrieval for structures and tables
- Message retrieval with empty input (no dump)
- Reference copying with unbound, bound, and plain value inputs
- Table filtering with multiple deletions and field subsets

https://claude.ai/code/session_01QQ9693gzErCqSbknH3nKdk